### PR TITLE
Rosters management

### DIFF
--- a/graphql/resolvers/roster.js
+++ b/graphql/resolvers/roster.js
@@ -26,7 +26,7 @@ async function setPlayers(roster, players) {
   await roster.setPlayers(
     await Player.findAll({
       where: {
-        id: { [Op.in]: players },
+        id: { [Op.in]: players || [] },
       },
     })
   );
@@ -106,7 +106,12 @@ module.exports = {
       if (typeof result === "undefined") throw new Error("Roster not found");
 
       if (typeof roster.name !== "undefined") result.name = roster.name;
-      result.save();
+
+      try {
+        await result.save();
+      } catch (saveError) {
+        throw saveError;
+      }
 
       return await setPlayers(result, roster.players);
     },

--- a/graphql/resolvers/roster.js
+++ b/graphql/resolvers/roster.js
@@ -1,0 +1,114 @@
+"use strict";
+
+const { Op } = require("sequelize");
+const { Roster, Player } = require("../../models");
+
+const PLAYER_INCLUDE = {
+  model: Player,
+  as: "players",
+  through: {
+    attributes: [],
+  },
+};
+
+// Avoid eager-loading if possible
+function getInclude(info) {
+  return info.fieldNodes[0].selectionSet.selections.find(
+    (field) => field.name.value === "players"
+  )
+    ? [PLAYER_INCLUDE]
+    : [];
+}
+
+async function setPlayers(roster, players) {
+  if (typeof players === "undefined") return roster;
+
+  await roster.setPlayers(
+    await Player.findAll({
+      where: {
+        id: { [Op.in]: players },
+      },
+    })
+  );
+
+  // `.reload()` is needed otherwise the instance would not be up-to-date
+  return roster.reload();
+}
+
+module.exports = {
+  Query: {
+    async findRosters(root, { filter }, { user }, info) {
+      if (!user) throw new Error("Unauthorized");
+
+      let include = getInclude(info);
+
+      if (typeof filter === "undefined") {
+        return await Roster.findAll({
+          order: [["name", "ASC"]],
+          include: include,
+        });
+      }
+
+      let queryFilter = [];
+
+      if (typeof filter.id !== "undefined") {
+        queryFilter.push({ id: { [Op.eq]: filter.id } });
+      }
+
+      if (typeof filter.name !== "undefined") {
+        queryFilter.push({ name: { [Op.iLike]: "%" + filter.name + "%" } });
+      }
+
+      return await Roster.findAll({
+        where: {
+          [Op.and]: queryFilter,
+        },
+        order: [["name", "ASC"]],
+        include: include,
+      });
+    },
+  },
+
+  Mutation: {
+    async createRoster(root, { roster }, { user }, info) {
+      if (!user || !user.isAdmin) throw new Error("Unauthorized");
+
+      let include = getInclude(info);
+
+      let result = await Roster.create(
+        {
+          name: roster.name,
+        },
+        {
+          include: include,
+        }
+      );
+
+      return await setPlayers(result, roster.players);
+    },
+
+    async deleteRoster(root, { id }, { user }, info) {
+      if (!user || !user.isAdmin) throw new Error("Unauthorized");
+
+      return await Roster.destroy({ where: { id: id } });
+    },
+
+    async updateRoster(root, { id, roster }, { user }, info) {
+      if (!user || !user.isAdmin) throw new Error("Unauthorized");
+
+      let include = getInclude(info);
+
+      let result = await Roster.findOne({
+        where: { id: id },
+        include: include,
+      });
+
+      if (typeof result === "undefined") throw new Error("Roster not found");
+
+      if (typeof roster.name !== "undefined") result.name = roster.name;
+      result.save();
+
+      return await setPlayers(result, roster.players);
+    },
+  },
+};

--- a/graphql/types/player.graphql
+++ b/graphql/types/player.graphql
@@ -2,6 +2,7 @@ type Player {
   id: ID!
   name: String!
   activisionId: String!
+  rosters: [Roster]
   createdAt: Date!
   updatedAt: Date
 }

--- a/graphql/types/roster.graphql
+++ b/graphql/types/roster.graphql
@@ -1,0 +1,32 @@
+type Roster {
+  id: ID!
+  name: String!
+  players: [Player]
+  createdAt: Date!
+  updatedAt: Date
+}
+
+input CreateRosterInput {
+  name: String!
+  players: [ID]
+}
+
+input UpdateRosterInput {
+  name: String
+  players: [ID]
+}
+
+input RosterFilter {
+  id: ID
+  name: String
+}
+
+type Mutation {
+  createRoster(roster: CreateRosterInput!): Roster!
+  updateRoster(id: ID!, roster: UpdateRosterInput!): Roster!
+  deleteRoster(id: ID!): Boolean!
+}
+
+type Query {
+  findRosters(filter: RosterFilter): [Roster]
+}

--- a/migrations/20201027152852-create-roster.js
+++ b/migrations/20201027152852-create-roster.js
@@ -1,0 +1,52 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    const transaction = await queryInterface.sequelize.transaction();
+    try {
+      await queryInterface.sequelize.query(
+        `CREATE TABLE rosters (
+          id             UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+          name           TEXT UNIQUE NOT NULL,
+          created_at     TIMESTAMP WITH TIME ZONE NOT NULL,
+          updated_at     TIMESTAMP WITH TIME ZONE NOT NULL
+        );`,
+        { transaction: transaction }
+      );
+
+      await queryInterface.sequelize.query(
+        `CREATE TABLE players_rosters (
+          player_id      UUID REFERENCES players(id),
+          roster_id      UUID REFERENCES rosters(id),
+          created_at     TIMESTAMP WITH TIME ZONE NOT NULL,
+          updated_at     TIMESTAMP WITH TIME ZONE NOT NULL,
+          PRIMARY KEY(player_id, roster_id)
+        );`,
+        { transaction: transaction }
+      );
+
+      await transaction.commit();
+    } catch (err) {
+      await transaction.rollback();
+      throw err;
+    }
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    const transaction = await queryInterface.sequelize.transaction();
+    try {
+      await queryInterface.sequelize.query(`DROP TABLE players_rosters;`, {
+        transaction: transaction,
+      });
+
+      await queryInterface.sequelize.query(`DROP TABLE rosters;`, {
+        transaction: transaction,
+      });
+
+      await transaction.commit();
+    } catch (err) {
+      await transaction.rollback();
+      throw err;
+    }
+  }
+};

--- a/models/roster.js
+++ b/models/roster.js
@@ -3,17 +3,17 @@
 const { Model } = require("sequelize");
 
 module.exports = (sequelize, DataTypes) => {
-  class Player extends Model {
+  class Roster extends Model {
     static associate(models) {
-      Player.belongsToMany(models.Roster, {
-        as: "rosters",
+      Roster.belongsToMany(models.Player, {
+        as: "players",
         through: "players_rosters",
-        foreignKey: "player_id",
-        otherKey: "roster_id",
+        foreignKey: "roster_id",
+        otherKey: "player_id",
       });
     }
   }
-  Player.init(
+  Roster.init(
     {
       id: {
         type: DataTypes.UUID,
@@ -26,17 +26,12 @@ module.exports = (sequelize, DataTypes) => {
         allowNull: false,
         unique: true,
       },
-      activisionId: {
-        type: DataTypes.TEXT,
-        allowNull: false,
-        unique: true,
-      },
     },
     {
       sequelize,
-      modelName: "Player",
+      modelName: "Roster",
     }
   );
 
-  return Player;
+  return Roster;
 };


### PR DESCRIPTION
Linked to #5 

First work on rosters management with many-to-many relationships to the players.

Currently, players can only be set in rosters via the createRoster or updateRoster mutations (i.e. rosters cannot be added through a Player-related mutation). But you can retrieve the relationships from both types. This can be changed/expanded depending on how it's used by the client.