### PR TITLE
Manually create WORKDIR in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ LABEL maintainer="ttirtia"
 
 USER node
 
+RUN mkdir -p /home/node/app
 WORKDIR /home/node/app
 
 COPY --chown=node:node package.json .


### PR DESCRIPTION
I have no idea how I managed to build this locally, but it doesn't work when using the Automated Builds on Docker Hub.