### PR TITLE
Open find tournaments query

### DIFF
--- a/graphql/resolvers/game.js
+++ b/graphql/resolvers/game.js
@@ -142,15 +142,20 @@ module.exports = {
       const team = await Team.findByPk(game.team, {
         include: [{ model: Tournament, as: "tournament" }],
       });
-      const teamLeaderUser = await (await team.getTeamLeader()).getUser();
+
+      const teamLeader = await team.getTeamLeader();
+      const teamLeaderUser = teamLeader ? await teamLeader.getUser() : null;
 
       // Only let admins and team leaders create game results
       if (
         !authUser ||
         team === null ||
-        (teamLeaderUser.length &&
+        (
+          teamLeaderUser &&
+          teamLeaderUser.length &&
           teamLeaderUser[0].id !== authUser.id &&
-          !authUser.isAdmin)
+          !authUser.isAdmin
+        )
       )
         throw new Error("Unauthorized");
 

--- a/graphql/resolvers/tournament.js
+++ b/graphql/resolvers/tournament.js
@@ -169,8 +169,6 @@ module.exports = {
     //  #### Returns
     //    * findTournaments: the list of tournaments with matching criteria or all tournaments if the filter is not defined
     async findTournaments(root, { filter, teamOrder }, { authUser }, info) {
-      if (!authUser) throw new Error("Unauthorized");
-
       const include = getInclude(info);
       const order = [["name", "ASC"]];
 

--- a/graphql/types/team.graphql
+++ b/graphql/types/team.graphql
@@ -3,7 +3,7 @@ type Team {
   name: String!
   placement: Int
   points: Int
-  teamLeader: Player!
+  teamLeader: Player
   players: [Player]!
   tournament: Tournament!
   games: [Game]
@@ -14,7 +14,7 @@ type Team {
 input CreateTeamInput {
   name: String!
   tournament: ID!
-  teamLeader: ID!
+  teamLeader: ID
   players: [ID]!
 }
 


### PR DESCRIPTION
Let people query for tournaments even if they're not authenticated. Also make the team leader optional in a team, so we don't have problems in case the player acting as leader is deleted.