### PR TITLE
Disable sequelize logging in production

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -22,5 +22,6 @@ module.exports = {
     define: {
       underscored: true,
     },
+    logging: false,
   },
 };


### PR DESCRIPTION
It's a bit too verbose in production.